### PR TITLE
add and reference project CSharpMarkup.Wpf

### DIFF
--- a/src/FamilyShow2022.sln
+++ b/src/FamilyShow2022.sln
@@ -7,20 +7,33 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.FamilyShow", "Mic
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.FamilyShowLib", "Microsoft.FamilyShowLib\Microsoft.FamilyShowLib.csproj", "{368F329D-7F70-4FE8-AACC-1D4F7A08AEE1}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharpMarkup.Wpf", "..\..\CSharpForMarkup\src\CSharpMarkup.Wpf\CSharpMarkup.Wpf.csproj", "{3B3DA35F-607D-4FB2-B50A-530C62BEF927}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Generate|Any CPU = Generate|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F88F79F0-C506-469A-8360-A3C845951F56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F88F79F0-C506-469A-8360-A3C845951F56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F88F79F0-C506-469A-8360-A3C845951F56}.Generate|Any CPU.ActiveCfg = Release|Any CPU
+		{F88F79F0-C506-469A-8360-A3C845951F56}.Generate|Any CPU.Build.0 = Release|Any CPU
 		{F88F79F0-C506-469A-8360-A3C845951F56}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F88F79F0-C506-469A-8360-A3C845951F56}.Release|Any CPU.Build.0 = Release|Any CPU
 		{368F329D-7F70-4FE8-AACC-1D4F7A08AEE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{368F329D-7F70-4FE8-AACC-1D4F7A08AEE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{368F329D-7F70-4FE8-AACC-1D4F7A08AEE1}.Generate|Any CPU.ActiveCfg = Release|Any CPU
+		{368F329D-7F70-4FE8-AACC-1D4F7A08AEE1}.Generate|Any CPU.Build.0 = Release|Any CPU
 		{368F329D-7F70-4FE8-AACC-1D4F7A08AEE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{368F329D-7F70-4FE8-AACC-1D4F7A08AEE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B3DA35F-607D-4FB2-B50A-530C62BEF927}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B3DA35F-607D-4FB2-B50A-530C62BEF927}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B3DA35F-607D-4FB2-B50A-530C62BEF927}.Generate|Any CPU.ActiveCfg = Generate|Any CPU
+		{3B3DA35F-607D-4FB2-B50A-530C62BEF927}.Generate|Any CPU.Build.0 = Generate|Any CPU
+		{3B3DA35F-607D-4FB2-B50A-530C62BEF927}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B3DA35F-607D-4FB2-B50A-530C62BEF927}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Microsoft.FamilyShow/Microsoft.FamilyShow.csproj
+++ b/src/Microsoft.FamilyShow/Microsoft.FamilyShow.csproj
@@ -34,6 +34,7 @@
 	</ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\CSharpForMarkup\src\CSharpMarkup.Wpf\CSharpMarkup.Wpf.csproj" />
     <ProjectReference Include="..\Microsoft.FamilyShowLib\Microsoft.FamilyShowLib.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
This is a temporary integration with C# Markup source, to be used until the WPF port of C# Markup is mature enough for publishing via NuGet.

This PR adds the [CSharpMarkup.Wpf](https://github.com/VincentH-Net/CSharpForMarkup/tree/wpf/src/CSharpMarkup.Wpf) project to `FamilyShow2022.sln` and references it in `Microsoft.FamilyShow.csproj`

How to use:

Fork the [WPF branch in the C# Markup repo](https://github.com/VincentH-Net/CSharpForMarkup/tree/wpf) to a  `CSharpForMarkup` sibling folder of the FamilyShow2022 repo folder, e.g:
![image](https://user-images.githubusercontent.com/1872271/148364319-4153af78-6204-4219-b9a3-c2e9b4a3c40d.png)
